### PR TITLE
fix(styling): Correctly apply CSS variables for gradients

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,9 @@
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar: var(--sidebar);
+  --color-sidebar-dark: var(--sidebar-dark);
+  --color-topbar-start: var(--topbar-start);
+  --color-topbar-end: var(--topbar-end);
   --color-chart-5: var(--chart-5);
   --color-chart-4: var(--chart-4);
   --color-chart-3: var(--chart-3);

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -3,7 +3,7 @@ import { LayoutDashboard, Users, Settings } from 'lucide-react';
 
 const Sidebar = () => {
   return (
-    <div className="w-64 bg-gradient-to-b from-[--sidebar] to-[--sidebar-dark] text-sidebar-foreground p-5">
+    <div className="w-64 bg-gradient-to-b from-sidebar to-sidebar-dark text-sidebar-foreground p-5">
       <h2 className="text-2xl font-bold mb-10 text-center">Admin</h2>
       <nav>
         <ul>

--- a/src/components/topbar.tsx
+++ b/src/components/topbar.tsx
@@ -3,7 +3,7 @@ import { Bell, User, Search } from 'lucide-react';
 
 const Topbar = () => {
   return (
-    <header className="bg-gradient-to-r from-[--topbar-start] to-[--topbar-end] text-white shadow-md p-4 flex justify-between items-center">
+    <header className="bg-gradient-to-r from-topbar-start to-topbar-end text-white shadow-md p-4 flex justify-between items-center">
       <div className="flex items-center">
         <h1 className="text-2xl font-bold">Dashboard</h1>
       </div>


### PR DESCRIPTION
The previous implementation used CSS variables directly in Tailwind's arbitrary value syntax (e.g., `from-[--sidebar]`). This was not being processed correctly, resulting in a white background on the sidebar and topbar, making the white text invisible.

This commit fixes the issue by:
1.  Registering the gradient color variables within the `@theme` block in `globals.css`.
2.  Updating the `sidebar.tsx` and `topbar.tsx` components to use the theme-aware utility classes (e.g., `from-sidebar`) instead of the arbitrary value syntax.